### PR TITLE
Use Personal Access Token to authenticate push

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,4 +24,5 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
+          github_token: ${{ secrets.GH_PAT }}
           branch: ${{ github.ref }}

--- a/logs/index.txt
+++ b/logs/index.txt
@@ -1,1 +1,1 @@
-Last Commited on Wed Jun 23 19:29:19 CEST 2021
+Last Commited on Wed Jun 23 17:42:21 UTC 2021

--- a/src/input.txt
+++ b/src/input.txt
@@ -1,1 +1,2 @@
 Hello
+Hello


### PR DESCRIPTION
With this modification, the push operated through the action triggers the check and validate the pull request.
Unfortunately, this not our expected behaviour. We'd rather have the the check not triggered, and the pull request not expecting any for merging.